### PR TITLE
feat(core): add resubmit badge variant with lime color tokens

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diditui/core",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "sideEffects": [
     "*.css"
@@ -240,7 +240,7 @@
     "vite-plugin-static-copy": "^3.1.1"
   },
   "peerDependencies": {
-    "@diditui/icons-react": "^0.0.17",
+    "@diditui/icons-react": "^0.0.18",
     "input-otp": "^1.4.2",
     "qrcode": "^1.5.4",
     "react": ">=18",

--- a/packages/core/src/components/badge.tsx
+++ b/packages/core/src/components/badge.tsx
@@ -24,6 +24,8 @@ const badgeVariants = tv({
         "bg-surface-warning-secondary border-warning-tertiary text-warning-primary [a&]:hover:bg-surface-warning-secondary/50",
       primary:
         "bg-transparent border-surface-brand-secondary text-brand-primary [a&]:hover:bg-surface-brand-secondary",
+      resubmit:
+        "bg-surface-resubmit-secondary border-resubmit-secondary text-resubmit-primary [a&]:hover:bg-surface-resubmit-secondary/50",
     },
     rounded: {
       "xs": "rounded-xs",

--- a/packages/core/src/tailwind/theme.css
+++ b/packages/core/src/tailwind/theme.css
@@ -264,6 +264,12 @@
   --color-error-tertiary: var(--color-red-100);
   --color-surface-error-secondary: var(--color-red-100);
 
+  /* RESUBMIT */
+  --color-resubmit-primary: #5c6b00;
+  --color-resubmit-secondary: #cde600;
+  --color-resubmit-tertiary: #cde60033;
+  --color-surface-resubmit-secondary: #cde60033;
+
   /* UTILITIES */
   --color-utility-overlay: var(--color-black);
   --color-utility-measurement: var(--color-measurement);

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diditui/icons-react",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "license": "MIT",
   "main": "./dist/cjs/didit-icons.cjs",
   "types": "./dist/esm/didit-icons.d.ts",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diditui/icons",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "license": "MIT",
   "exports": {
     "./*": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a small, UI-only change adding new theme color tokens and a `Badge` variant, plus routine package version/peerDependency bumps.
> 
> **Overview**
> Adds a new `Badge` `variant="resubmit"` with corresponding Tailwind classes, backed by newly introduced `--color-resubmit-*` and `--color-surface-resubmit-secondary` tokens in `theme.css`.
> 
> Bumps `@diditui/core`, `@diditui/icons`, and `@diditui/icons-react` versions to `0.0.18`, and updates `@diditui/core`’s `@diditui/icons-react` peer dependency to `^0.0.18`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aecd402574e7d0d34ccfb3598ce8184adef7b08a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->